### PR TITLE
Enhance orientation handling in InteractivePreview and Preview classes

### DIFF
--- a/Sources/Aespa/View/InteractivePreview.swift
+++ b/Sources/Aespa/View/InteractivePreview.swift
@@ -112,6 +112,11 @@ public struct InteractivePreview: View {
                     .opacity(focusFrameOpacity)
                     .animation(.spring(), value: focusFrameOpacity)
             }
+            .onChange(of: geometry.size) { newSize in
+                DispatchQueue.main.async {
+                    layer.frame = CGRect(origin: .zero, size: newSize)
+                }
+            }
         }
     }
 }

--- a/Sources/Aespa/View/Preview.swift
+++ b/Sources/Aespa/View/Preview.swift
@@ -32,9 +32,12 @@ struct Preview: UIViewControllerRepresentable {
     
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
         previewLayer.videoGravity = gravity
-        uiViewController.view.layer.addSublayer(previewLayer)
-        
-        previewLayer.frame = uiViewController.view.bounds
+        if previewLayer.superlayer == nil {
+            uiViewController.view.layer.addSublayer(previewLayer)
+        }
+        DispatchQueue.main.async {
+            self.previewLayer.frame = uiViewController.view.bounds
+        }
     }
     
     func dismantleUIViewController(_ uiViewController: UIViewController, coordinator: ()) {


### PR DESCRIPTION
# Summary

Improved the handling of orientation changes in the `InteractivePreview` and `Preview` classes to ensure proper resizing and layout adjustments of the `AVCaptureVideoPreviewLayer` during device rotation. These changes address issues where the preview layer would not correctly adapt to new geometry sizes, leading to misalignment.

# Details

1. `InteractivePreview`:
	- Added an `onChange` modifier to observe changes in the geometry size.
	- Updated the `layer` frame on the main dispatch queue to ensure proper resizing.

2. `Preview`:
	- Removed the direct assignment of `previewLayer.frame` in `updateUIViewController`.
	- Ensured the `previewLayer` is added to the view controller’s layer only if it hasn’t been added already.
	- Updated the `previewLayer.frame` on the main dispatch queue to ensure it resizes correctly when the view bounds change.

# Note

This will not affect the orientation of the session. To do that, application code must wrap the preview layer with handlers that call `aespaSession.common(.orientation(orientation: ...))`. I have some code that demonstrates this, but it's very specific to my app, so I couldn't cleanly extract a good example for the README. I can try to tackle that in a future commit.