### PR TITLE
Respect photoQualityPrioritization in custom capture settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ import Aespa
 <!-- INSERT_CODE: GETTING_STARTED -->
 ```swift
 let option = AespaOption(albumName: "YOUR_ALBUM_NAME")
-let aespaSession = Aespa.session(with: option)
+self.aespaSession = Aespa.session(with: option)
 ```
 <!-- INSERT_CODE: END -->
 

--- a/Scripts/gen-mocks.sh
+++ b/Scripts/gen-mocks.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Cuckoo's `run` script resolves the `version` file relative to CWD.
+cd "$(dirname "$0")" || exit 1
+
 ROOT_PATH=$(git rev-parse --show-toplevel)
 if [ -z "$ROOT_PATH" ]; then
     echo "❌ Error: Could not find repository root."
@@ -18,7 +21,9 @@ PROJECT_NAME="Aespa"
 TESTER_NAME="TestHostApp"
 PACKAGE_SOURCE_PATH="${ROOT_PATH}/Sources/Aespa"
 OUTPUT_FILE="${ROOT_PATH}/Tests/Tests/Mock/GeneratedMocks.swift"
-SWIFT_FILES=$(find "$PACKAGE_SOURCE_PATH" -type f -name "*.swift" -not -path "*/Context/*" -not -path "*/Loader/*" -print0 | xargs -0)
+# AespaCoreSession.swift is excluded because cuckoo_generator 1.10.3 segfaults
+# on its @Sendable closure type annotations; no test uses MockAespaCoreSession.
+SWIFT_FILES=$(find "$PACKAGE_SOURCE_PATH" -type f -name "*.swift" -not -path "*/Context/*" -not -path "*/Loader/*" -not -name "AespaCoreSession.swift" -print0 | xargs -0)
 
 
 echo "✅ Generated Mocks File = ${OUTPUT_FILE}"

--- a/Sources/Aespa/Core/Representable/AespaCoreSession+AespaRepresentable.swift
+++ b/Sources/Aespa/Core/Representable/AespaCoreSession+AespaRepresentable.swift
@@ -54,7 +54,7 @@ nonisolated public protocol AespaCoreSessionRepresentable {
     /// Throws an error if the operation fails.
     func addMovieFileOutput() throws
 
-    /// Adds photo file output to the session.
+    /// Adds photo file output to the session, allowing captures up to `.quality` prioritization.
     /// Throws an error if the operation fails.
     func addCapturePhotoOutput() throws
 

--- a/Sources/Aespa/Core/Representable/AespaCoreSession+AespaRepresentable.swift
+++ b/Sources/Aespa/Core/Representable/AespaCoreSession+AespaRepresentable.swift
@@ -179,6 +179,7 @@ nonisolated extension AespaCoreSession: AespaCoreSessionRepresentable {
         }
 
         self.addOutput(photoOutput)
+        photoOutput.maxPhotoQualityPrioritization = .quality
     }
 
     // MARK: - Option related

--- a/Tests/TestHostApp.xcodeproj/project.pbxproj
+++ b/Tests/TestHostApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		9C4BBE622A400E450071C84F /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4BBE572A400E450071C84F /* MockFileManager.swift */; };
 		9C4BBE642A400E450071C84F /* FileOutputProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4BBE5A2A400E450071C84F /* FileOutputProcessorTests.swift */; };
 		9C4BBE682A4011460071C84F /* CapturePhotoOutputProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4BBE672A4011460071C84F /* CapturePhotoOutputProcessorTests.swift */; };
+		A15B10012E0000010000C51A /* CoreSessionRepresentableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15B10002E0000010000C51A /* CoreSessionRepresentableTests.swift */; };
 		9C4BBE6C2A4013F90071C84F /* AssetProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4BBE6B2A4013F80071C84F /* AssetProcessorTests.swift */; };
 		9C727D082A3FEF9600EF9472 /* TestHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C727D072A3FEF9600EF9472 /* TestHostAppApp.swift */; };
 		9C727D0A2A3FEF9600EF9472 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C727D092A3FEF9600EF9472 /* ContentView.swift */; };
@@ -64,6 +65,7 @@
 		9C4BBE572A400E450071C84F /* MockFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		9C4BBE5A2A400E450071C84F /* FileOutputProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileOutputProcessorTests.swift; sourceTree = "<group>"; };
 		9C4BBE672A4011460071C84F /* CapturePhotoOutputProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePhotoOutputProcessorTests.swift; sourceTree = "<group>"; };
+		A15B10002E0000010000C51A /* CoreSessionRepresentableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSessionRepresentableTests.swift; sourceTree = "<group>"; };
 		9C4BBE6B2A4013F80071C84F /* AssetProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetProcessorTests.swift; sourceTree = "<group>"; };
 		9C727D042A3FEF9600EF9472 /* TestHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C727D072A3FEF9600EF9472 /* TestHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHostAppApp.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				9C4BBE4C2A400E450071C84F /* Tuner */,
 				9C4BBE582A400E450071C84F /* Processor */,
 				9C4BBE502A400E450071C84F /* Util */,
+				A15B10022E0000010000C51A /* Core */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -173,6 +176,14 @@
 				9C4BBE552A400E450071C84F /* video.mp4 */,
 			);
 			path = Asset;
+			sourceTree = "<group>";
+		};
+		A15B10022E0000010000C51A /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				A15B10002E0000010000C51A /* CoreSessionRepresentableTests.swift */,
+			);
+			path = Core;
 			sourceTree = "<group>";
 		};
 		9C4BBE582A400E450071C84F /* Processor */ = {
@@ -475,6 +486,7 @@
 				63F07BDD2B16DEAC0003BC1E /* GeneratedMocks.swift in Sources */,
 				9C4BBE5D2A400E450071C84F /* ConnectionTunerTests.swift in Sources */,
 				9C4BBE682A4011460071C84F /* CapturePhotoOutputProcessorTests.swift in Sources */,
+				A15B10012E0000010000C51A /* CoreSessionRepresentableTests.swift in Sources */,
 				9CD12FFE2A454B770012D1E1 /* MockImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Tests/Core/CoreSessionRepresentableTests.swift
+++ b/Tests/Tests/Core/CoreSessionRepresentableTests.swift
@@ -1,0 +1,21 @@
+//
+//  CoreSessionRepresentableTests.swift
+//  TestHostAppTests
+//
+//  Created by Young Bin on 2026/06/10.
+//
+
+import XCTest
+import AVFoundation
+
+@testable import Aespa
+
+final class CoreSessionRepresentableTests: XCTestCase {
+    func testAddCapturePhotoOutputRaisesMaxPhotoQualityPrioritization() throws {
+        let session = AespaCoreSession(option: AespaOption(albumName: nil))
+
+        try session.addCapturePhotoOutput()
+
+        XCTAssertEqual(session.photoOutput?.maxPhotoQualityPrioritization, .quality)
+    }
+}

--- a/Tests/Tests/Core/CoreSessionRepresentableTests.swift
+++ b/Tests/Tests/Core/CoreSessionRepresentableTests.swift
@@ -15,6 +15,7 @@ final class CoreSessionRepresentableTests: XCTestCase {
         let session = AespaCoreSession(option: AespaOption(albumName: nil))
 
         try session.addCapturePhotoOutput()
+        try session.addCapturePhotoOutput()
 
         XCTAssertEqual(session.photoOutput?.maxPhotoQualityPrioritization, .quality)
     }


### PR DESCRIPTION
## Summary

Fixes #51.

Capturing with custom `AVCapturePhotoSettings` that request `photoQualityPrioritization = .quality` crashed with:

```
NSInvalidArgumentException: settings.photoQualityPrioritization must not be higher than self.maxPhotoQualityPrioritization
```

`addCapturePhotoOutput()` created the `AVCapturePhotoOutput` with its default max (`.balanced`) and nothing ever raised it.

## Changes

- Set `photoOutput.maxPhotoQualityPrioritization = .quality` right after the output is added to the session, mirroring Apple's AVCam sample. This only lifts the ceiling for per-capture settings — the per-capture default stays `.balanced`, so existing capture behavior and latency are unchanged. It runs before `startRunning()`, so no mid-session pipeline reconfiguration is triggered.
- Add `CoreSessionRepresentableTests` asserting the property after (repeated) `addCapturePhotoOutput()` calls, wired into TestHostApp.
- Fix `Scripts/gen-mocks.sh`, which was broken in two ways: it only worked when invoked from inside `Scripts/` (Cuckoo's `run` script resolves the `version` file relative to CWD), and cuckoo_generator 1.10.3 segfaults parsing the `@Sendable` closure annotations introduced in #70 — `AespaCoreSession.swift` is now excluded from generator input (no test uses `MockAespaCoreSession`). This unblocks the "Generate mock file" build phase, i.e. every local/CI test build.
- Sync the README getting-started snippet with `Tests/ExampleCode` (regenerated by the update-readme build phase).

## Test plan

- `xcodebuild test` (TestHostApp, Test plan, iPhone 17 Pro simulator): 27 tests pass, including the new one, with mock generation running end-to-end during the build.
- The crash itself only reproduces with a physical camera; correctness rests on the AVFoundation contract above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Photo capture output now supports maximum quality prioritization for enhanced image capture results.

* **Tests**
  * Added unit tests validating photo output quality prioritization behavior.

* **Documentation**
  * Updated Swift "Getting Started" example demonstrating proper session property initialization patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->